### PR TITLE
Fix Vercel configuration error

### DIFF
--- a/summarit/vercel.json
+++ b/summarit/vercel.json
@@ -1,12 +1,6 @@
 {
   "version": 2,
   "buildCommand": "npm run vercel-build",
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/next"
-    }
-  ],
   "routes": [
     {
       "src": "/api/(.*)",
@@ -15,10 +9,5 @@
   ],
   "env": {
     "NODE_ENV": "production"
-  },
-  "functions": {
-    "src/app/api/**/*.ts": {
-      "runtime": "nodejs18.x"
-    }
   }
 }


### PR DESCRIPTION
- Removed conflicting 'functions' and 'builds' properties from vercel.json
- Simplified configuration to use only routes and environment variables
- This resolves the 'functions property cannot be used with builds property' error